### PR TITLE
Fix city filter and chatbox display

### DIFF
--- a/client/src/components/LocationSelector.jsx
+++ b/client/src/components/LocationSelector.jsx
@@ -46,13 +46,16 @@ export default function LocationSelector({ value, onChange, mode = "form" }) {
   const selectedCities = value.cities || [];
   const handleCitySelect = (cityName) => {
     if (selectedCities.includes(cityName)) {
-      onChange({ ...value, cities: selectedCities.filter((c) => c !== cityName) });
+      const newCities = selectedCities.filter((c) => c !== cityName);
+      onChange({ ...value, cities: newCities, city: newCities.length > 0 ? newCities[0] : "" });
     } else {
-      onChange({ ...value, cities: [...selectedCities, cityName] });
+      const newCities = [...selectedCities, cityName];
+      onChange({ ...value, cities: newCities, city: cityName });
     }
   };
   const handleRemoveCity = (cityName) => {
-    onChange({ ...value, cities: selectedCities.filter((c) => c !== cityName) });
+    const newCities = selectedCities.filter((c) => c !== cityName);
+    onChange({ ...value, cities: newCities, city: newCities.length > 0 ? newCities[0] : "" });
   };
 
   // Keyboard navigation for city dropdown (search mode only)

--- a/client/src/pages/AdminAppointments.jsx
+++ b/client/src/pages/AdminAppointments.jsx
@@ -1724,20 +1724,20 @@ function AdminAppointmentRow({
                         ref={el => messageRefs.current[c._id] = el}
                         className={`rounded-2xl px-4 py-2 text-sm shadow-lg max-w-[80%] break-words relative ${isMe ? 'bg-gradient-to-r from-blue-400 to-blue-600 text-white' : 'bg-white text-gray-800 border border-gray-200'}`}
                       >
-                        {/* Reply preview above message if this is a reply */}
-                        {c.replyTo && (
-                          <div className="border-l-4 border-blue-300 pl-2 mb-1 text-xs text-gray-500 bg-blue-50 rounded w-full max-w-full break-words cursor-pointer" onClick={() => {
-                              if (messageRefs.current[c.replyTo]) {
-                                messageRefs.current[c.replyTo].scrollIntoView({ behavior: 'smooth', block: 'center' });
-                                messageRefs.current[c.replyTo].classList.add('ring-2', 'ring-yellow-400');
-                                setTimeout(() => {
-                                  messageRefs.current[c.replyTo].classList.remove('ring-2', 'ring-yellow-400');
-                                }, 1000);
-                              }
-                            }} role="button" tabIndex={0} aria-label="Go to replied message">
-                            <span className="text-xs text-gray-600 truncate">{localComments.find(msg => msg._id === c.replyTo)?.message || 'Original message'}</span>
-                          </div>
-                        )}
+                                                    {/* Reply preview above message if this is a reply */}
+                            {c.replyTo && (
+                              <div className="border-l-4 border-blue-300 pl-2 mb-1 text-xs text-gray-500 bg-blue-50 rounded w-full max-w-full break-words cursor-pointer" onClick={() => {
+                                  if (messageRefs.current[c.replyTo]) {
+                                    messageRefs.current[c.replyTo].scrollIntoView({ behavior: 'smooth', block: 'center' });
+                                    messageRefs.current[c.replyTo].classList.add('ring-2', 'ring-yellow-400');
+                                    setTimeout(() => {
+                                      messageRefs.current[c.replyTo].classList.remove('ring-2', 'ring-yellow-400');
+                                    }, 1000);
+                                  }
+                                }} role="button" tabIndex={0} aria-label="Go to replied message">
+                                <span className="text-xs text-gray-600 truncate max-w-[200px]">{localComments.find(msg => msg._id === c.replyTo)?.message?.substring(0, 50) || 'Original message'}{localComments.find(msg => msg._id === c.replyTo)?.message?.length > 50 ? '...' : ''}</span>
+                              </div>
+                            )}
                         <div className="font-semibold mb-1 flex items-center gap-2 justify-start text-left">
                           <span className="truncate max-w-[60%] min-w-[80px] inline-block align-middle overflow-hidden text-ellipsis text-left">
                             {isMe ? "You" : (() => {
@@ -1920,16 +1920,16 @@ function AdminAppointmentRow({
                 
                 <div ref={chatEndRef} />
               </div>
-              {/* Reply indicator */}
-              {replyTo && (
-                <div className="px-4 mb-2">
-                  <div className="flex items-center bg-blue-50 border-l-4 border-blue-400 px-2 py-1 rounded">
-                    <span className="text-xs text-gray-700 font-semibold mr-2">Replying to:</span>
-                    <span className="text-xs text-gray-600 truncate">{replyTo.message}</span>
-                    <button className="ml-auto text-gray-400 hover:text-gray-700" onClick={() => setReplyTo(null)} title="Cancel reply">&times;</button>
+                              {/* Reply indicator */}
+                {replyTo && (
+                  <div className="px-4 mb-2">
+                    <div className="flex items-center bg-blue-50 border-l-4 border-blue-400 px-2 py-1 rounded">
+                      <span className="text-xs text-gray-700 font-semibold mr-2">Replying to:</span>
+                      <span className="text-xs text-gray-600 truncate max-w-[300px]">{replyTo.message?.substring(0, 80)}{replyTo.message?.length > 80 ? '...' : ''}</span>
+                      <button className="ml-auto text-gray-400 hover:text-gray-700" onClick={() => setReplyTo(null)} title="Cancel reply">&times;</button>
+                    </div>
                   </div>
-                </div>
-              )}
+                )}
               
               {/* Edit indicator */}
               {editingComment && (

--- a/client/src/pages/AdminExplore.jsx
+++ b/client/src/pages/AdminExplore.jsx
@@ -93,7 +93,9 @@ export default function AdminExplore() {
 
   const handleLocationChange = (loc) => {
     setLocationFilter(loc);
-    setFormData((prev) => ({ ...prev, state: loc.state, district: loc.district, city: loc.city }));
+    // For search mode, use the first city from cities array or single city
+    const cityValue = loc.cities && loc.cities.length > 0 ? loc.cities[0] : loc.city;
+    setFormData((prev) => ({ ...prev, state: loc.state, district: loc.district, city: cityValue }));
   };
 
   if (loading) {

--- a/client/src/pages/MyAppointments.jsx
+++ b/client/src/pages/MyAppointments.jsx
@@ -2126,7 +2126,7 @@ function AppointmentRow({ appt, currentUser, handleStatusUpdate, handleAdminDele
                                     }, 1000);
                                   }
                                 }} role="button" tabIndex={0} aria-label="Go to replied message">
-                                <span className="text-xs text-gray-600 truncate">{comments.find(msg => msg._id === c.replyTo)?.message || 'Original message'}</span>
+                                <span className="text-xs text-gray-600 truncate max-w-[200px]">{comments.find(msg => msg._id === c.replyTo)?.message?.substring(0, 50) || 'Original message'}{comments.find(msg => msg._id === c.replyTo)?.message?.length > 50 ? '...' : ''}</span>
                               </div>
                             )}
                             <div className="font-semibold mb-1 flex items-center gap-2 flex-wrap break-all">
@@ -2253,7 +2253,7 @@ function AppointmentRow({ appt, currentUser, handleStatusUpdate, handleAdminDele
                   <div className="px-4 mb-2">
                     <div className="flex items-center bg-blue-50 border-l-4 border-blue-400 px-2 py-1 rounded">
                       <span className="text-xs text-gray-700 font-semibold mr-2">Replying to:</span>
-                      <span className="text-xs text-gray-600 truncate">{replyTo.message}</span>
+                      <span className="text-xs text-gray-600 truncate max-w-[300px]">{replyTo.message?.substring(0, 80)}{replyTo.message?.length > 80 ? '...' : ''}</span>
                       <button className="ml-auto text-gray-400 hover:text-gray-700" onClick={() => setReplyTo(null)} title="Cancel reply">&times;</button>
                     </div>
                   </div>

--- a/client/src/pages/PublicSearch.jsx
+++ b/client/src/pages/PublicSearch.jsx
@@ -110,9 +110,7 @@ export default function PublicSearch() {
 
     const handleLocationChange = (loc) => {
         setLocationFilter(loc);
-        // For search mode, use the first city from cities array or single city
-        const cityValue = loc.cities && loc.cities.length > 0 ? loc.cities[0] : loc.city;
-        setFormData((prev) => ({ ...prev, state: loc.state, district: loc.district, city: cityValue }));
+        setFormData((prev) => ({ ...prev, state: loc.state, district: loc.district, city: loc.city }));
     };
 
     if (loading) {

--- a/client/src/pages/PublicSearch.jsx
+++ b/client/src/pages/PublicSearch.jsx
@@ -110,7 +110,9 @@ export default function PublicSearch() {
 
     const handleLocationChange = (loc) => {
         setLocationFilter(loc);
-        setFormData((prev) => ({ ...prev, state: loc.state, district: loc.district, city: loc.city }));
+        // For search mode, use the first city from cities array or single city
+        const cityValue = loc.cities && loc.cities.length > 0 ? loc.cities[0] : loc.city;
+        setFormData((prev) => ({ ...prev, state: loc.state, district: loc.district, city: cityValue }));
     };
 
     if (loading) {

--- a/client/src/pages/Search.jsx
+++ b/client/src/pages/Search.jsx
@@ -110,7 +110,9 @@ export default function Search() {
 
     const handleLocationChange = (loc) => {
         setLocationFilter(loc);
-        setFormData((prev) => ({ ...prev, state: loc.state, district: loc.district, city: loc.city }));
+        // For search mode, use the first city from cities array or single city
+        const cityValue = loc.cities && loc.cities.length > 0 ? loc.cities[0] : loc.city;
+        setFormData((prev) => ({ ...prev, state: loc.state, district: loc.district, city: cityValue }));
     };
 
     if (loading) {


### PR DESCRIPTION
Fix city filter in explore pages and truncate long chat reply messages.

The city filter was not working because the `LocationSelector` component in search mode was updating a `cities` array, but the backend expected a single `city` parameter. This PR ensures the `city` field is correctly populated for search queries. Additionally, long chat reply messages were causing UI disorientation; they are now truncated to prevent overflow.

---
<a href="https://cursor.com/background-agent?bcId=bc-45035455-7589-40c7-b62f-83e4672d3bd7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-45035455-7589-40c7-b62f-83e4672d3bd7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>