### PR TITLE
Fix blank quick actions on wishlist open

### DIFF
--- a/client/src/pages/AdminWishlist.jsx
+++ b/client/src/pages/AdminWishlist.jsx
@@ -8,6 +8,7 @@ import { useState } from 'react';
 export default function AdminWishlist() {
   const { wishlist, loading } = useWishlist();
   const [showTooltip, setShowTooltip] = useState(false);
+  const navigate = useNavigate(); // Move this hook call before conditional return
 
   if (loading) {
     return (
@@ -23,7 +24,6 @@ export default function AdminWishlist() {
     );
   }
 
-  const navigate = useNavigate();
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 to-purple-100 py-10 px-2 md:px-8">
       <div className="max-w-6xl mx-auto bg-white rounded-xl shadow-lg p-6 relative">

--- a/client/src/pages/WishList.jsx
+++ b/client/src/pages/WishList.jsx
@@ -8,6 +8,7 @@ import { useState } from 'react';
 const WishList = () => {
   const { wishlist, loading } = useWishlist();
   const [showTooltip, setShowTooltip] = useState(false);
+  const navigate = useNavigate(); // Move this hook call before conditional return
 
   if (loading) {
     return (
@@ -23,7 +24,6 @@ const WishList = () => {
     );
   }
 
-  const navigate = useNavigate();
   return (
     <div className="bg-gradient-to-br from-blue-50 to-purple-100 min-h-screen py-10 px-2 md:px-8">
       <div className="max-w-6xl mx-auto bg-white rounded-xl shadow-lg p-6 relative">


### PR DESCRIPTION
Fixes React error #310 by moving `useNavigate` calls before conditional returns in WishList components.

The error "Rendered more hooks than during the previous render" occurred because `useNavigate` was conditionally called after an early `if (loading)` return, violating the Rules of Hooks. Moving it to the top of the component ensures all hooks are called consistently on every render.

---
<a href="https://cursor.com/background-agent?bcId=bc-a9fe70d3-59e4-4d65-86a2-7c201d61fece">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a9fe70d3-59e4-4d65-86a2-7c201d61fece">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>