### PR TITLE
Shrink scroll to bottom icon in chatboxes

### DIFF
--- a/client/src/pages/AdminAppointments.jsx
+++ b/client/src/pages/AdminAppointments.jsx
@@ -2067,13 +2067,13 @@ function AdminAppointmentRow({
                  <div className="absolute bottom-20 right-6 z-20">
                    <button
                      onClick={scrollToBottom}
-                     className="bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white rounded-full p-4 shadow-xl transition-all duration-200 hover:scale-110 relative transform hover:shadow-2xl"
+                     className="bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white rounded-full p-3 shadow-xl transition-all duration-200 hover:scale-110 relative transform hover:shadow-2xl"
                      title={unreadNewMessages > 0 ? `${unreadNewMessages} new message${unreadNewMessages > 1 ? 's' : ''}` : "Scroll to bottom"}
                      aria-label={unreadNewMessages > 0 ? `${unreadNewMessages} new messages, scroll to bottom` : "Scroll to bottom"}
                    >
                      <svg
-                       width="20"
-                       height="20"
+                       width="16"
+                       height="16"
                        viewBox="0 0 24 24"
                        fill="currentColor"
                        className="transform"

--- a/client/src/pages/MyAppointments.jsx
+++ b/client/src/pages/MyAppointments.jsx
@@ -2414,13 +2414,13 @@ function AppointmentRow({ appt, currentUser, handleStatusUpdate, handleAdminDele
               <div className="absolute bottom-20 right-6 z-20">
                 <button
                   onClick={scrollToBottom}
-                  className="bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white rounded-full p-4 shadow-xl transition-all duration-200 hover:scale-110 relative transform hover:shadow-2xl"
+                  className="bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white rounded-full p-3 shadow-xl transition-all duration-200 hover:scale-110 relative transform hover:shadow-2xl"
                   title={unreadNewMessages > 0 ? `${unreadNewMessages} new message${unreadNewMessages > 1 ? 's' : ''}` : "Scroll to bottom"}
                   aria-label={unreadNewMessages > 0 ? `${unreadNewMessages} new messages, scroll to bottom` : "Scroll to bottom"}
                 >
                   <svg
-                    width="20"
-                    height="20"
+                    width="16"
+                    height="16"
                     viewBox="0 0 24 24"
                     fill="currentColor"
                     className="transform"


### PR DESCRIPTION
Reduce the size of the scroll-to-bottom icon in chatboxes on appointment pages to make them less prominent.

---
<a href="https://cursor.com/background-agent?bcId=bc-2145f7f2-6178-44af-9a9e-cdd3da5617fb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2145f7f2-6178-44af-9a9e-cdd3da5617fb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>