### PR TITLE
Fix chat word breaking at line end

### DIFF
--- a/client/src/pages/AdminAppointments.jsx
+++ b/client/src/pages/AdminAppointments.jsx
@@ -1989,7 +1989,7 @@ function AdminAppointmentRow({
                       <div className={`flex w-full ${isMe ? 'justify-end' : 'justify-start'} animate-fadeInChatBubble`} style={{ animationDelay: `${0.03 * index}s` }}>
                       <div 
                         ref={el => messageRefs.current[c._id] = el}
-                        className={`rounded-2xl px-4 sm:px-5 py-3 text-sm shadow-xl max-w-[90%] sm:max-w-[80%] md:max-w-[70%] break-all overflow-hidden relative transition-all duration-200 min-h-[60px] ${
+                        className={`rounded-2xl px-4 sm:px-5 py-3 text-sm shadow-xl max-w-[90%] sm:max-w-[80%] md:max-w-[70%] break-words overflow-hidden relative transition-all duration-200 min-h-[60px] ${
                           isMe 
                             ? 'bg-gradient-to-r from-blue-600 to-purple-700 hover:from-blue-500 hover:to-purple-600 text-white shadow-blue-200 hover:shadow-blue-300' 
                             : 'bg-white hover:bg-gray-50 text-gray-800 border border-gray-200 shadow-gray-200 hover:shadow-lg hover:border-gray-300'
@@ -2081,9 +2081,9 @@ function AdminAppointmentRow({
                                         }
                                         
                                         if (c.originalMessage) {
-                                          return <span className="whitespace-pre-wrap break-all">{c.originalMessage}</span>;
+                                          return <span className="whitespace-pre-wrap break-words">{c.originalMessage}</span>;
                                         } else if (c.message) {
-                                          return <span className="whitespace-pre-wrap break-all">{c.message}</span>;
+                                          return <span className="whitespace-pre-wrap break-words">{c.message}</span>;
                                         } else {
                                           return (
                                             <span className="text-gray-500 italic">
@@ -2127,7 +2127,7 @@ function AdminAppointmentRow({
                                 </div>
                               ) : (
                                                                   <>
-                                    <span className="whitespace-pre-wrap break-all">{(c.message || '').replace(/\n+$/, '')}</span>
+                                    <span className="whitespace-pre-wrap break-words">{(c.message || '').replace(/\n+$/, '')}</span>
                                     {c.edited && (
                                       <span className="ml-2 text-[10px] italic text-gray-300 whitespace-nowrap">(Edited)</span>
                                     )}

--- a/client/src/pages/MyAppointments.jsx
+++ b/client/src/pages/MyAppointments.jsx
@@ -2659,7 +2659,7 @@ function AppointmentRow({ appt, currentUser, handleStatusUpdate, handleAdminDele
                           <div
                             ref={el => messageRefs.current[c._id] = el}
                             data-message-id={c._id}
-                            className={`rounded-2xl px-4 sm:px-5 py-3 text-sm shadow-xl max-w-[90%] sm:max-w-[80%] md:max-w-[70%] break-all overflow-hidden relative transition-all duration-200 min-h-[60px] ${
+                            className={`rounded-2xl px-4 sm:px-5 py-3 text-sm shadow-xl max-w-[90%] sm:max-w-[80%] md:max-w-[70%] break-words overflow-hidden relative transition-all duration-200 min-h-[60px] ${
                               isMe 
                                 ? 'bg-gradient-to-r from-blue-600 to-purple-700 hover:from-blue-500 hover:to-purple-600 text-white shadow-blue-200 hover:shadow-blue-300' 
                                 : 'bg-white hover:bg-gray-50 text-gray-800 border border-gray-200 shadow-gray-200 hover:shadow-lg hover:border-gray-300'
@@ -2700,7 +2700,7 @@ function AppointmentRow({ appt, currentUser, handleStatusUpdate, handleAdminDele
                                     </div>
                                   ) : (
                                     <>
-                                      <span className="whitespace-pre-wrap break-all">{(c.message || '').replace(/\n+$/, '')}</span>
+                                      <span className="whitespace-pre-wrap break-words">{(c.message || '').replace(/\n+$/, '')}</span>
                                       {c.edited && (
                                         <span className="ml-2 text-[10px] italic text-gray-300 whitespace-nowrap">(Edited)</span>
                                       )}


### PR DESCRIPTION
Replaced `break-all` with `break-words` in chat messages to prevent incorrect word breaking at line endings.

---
<a href="https://cursor.com/background-agent?bcId=bc-aeb3ad70-6f6e-4168-b942-419223eb0e70">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aeb3ad70-6f6e-4168-b942-419223eb0e70">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

