### PR TITLE
Fix chat unlock on myappointments page

### DIFF
--- a/client/dist/index.html
+++ b/client/dist/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>UrbanSetu</title>
-    <script type="module" crossorigin src="/assets/index-Ca9VhjSe.js"></script>
+    <script type="module" crossorigin src="/assets/index-Da1M2d2X.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-C8gwusbD.css">
   </head>
   <body>


### PR DESCRIPTION
Move chat unlock functions and password modal to `AppointmentRow` component to resolve chat unlock failure.

The chat unlock functionality failed because the relevant functions and the password modal were defined in the outer `MyAppointments` component scope, lacking access to the `appt` object and associated state variables like `isChatLocked` and `showPasswordModal`, which are specific to each `AppointmentRow`. Moving them into the `AppointmentRow` component ensures proper access and state management.

---
<a href="https://cursor.com/background-agent?bcId=bc-306d67aa-e72f-4c90-b6f8-d84e98131671">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-306d67aa-e72f-4c90-b6f8-d84e98131671">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

