### PR TITLE
Implement appointment archiving and unarchiving features

### DIFF
--- a/api/models/booking.model.js
+++ b/api/models/booking.model.js
@@ -108,6 +108,8 @@ const bookingSchema = new mongoose.Schema({
   visibleToBuyer: { type: Boolean, default: true },
   visibleToSeller: { type: Boolean, default: true },
   archivedByAdmin: { type: Boolean, default: false },
+  archivedByBuyer: { type: Boolean, default: false },
+  archivedBySeller: { type: Boolean, default: false },
   archivedAt: {
     type: Date
   },

--- a/client/dist/index.html
+++ b/client/dist/index.html
@@ -7,8 +7,8 @@
     <link rel="shortcut icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>UrbanSetu</title>
-    <script type="module" crossorigin src="/assets/index-AvFVyJ9K.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-BoccM3g9.css">
+    <script type="module" crossorigin src="/assets/index-DS1ugS9M.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-CRIgmQoQ.css">
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
Implement user-specific appointment archiving and unarchiving features in MyAppointments page.

Previously, only administrators could archive appointments. This PR extends the archiving functionality to individual users (buyers and sellers), allowing them to archive their own appointments locally. It introduces new `archivedByBuyer` and `archivedBySeller` fields in the backend and updates the frontend to provide a dedicated 'Archived Appointments' view with unarchive capabilities, similar to the admin experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-0974d42c-37c9-49d5-9552-1cc19b9d9366">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0974d42c-37c9-49d5-9552-1cc19b9d9366">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

