### PR TITLE
Fix null reading error on blank pages

### DIFF
--- a/client/src/WishlistContext.jsx
+++ b/client/src/WishlistContext.jsx
@@ -66,9 +66,13 @@ const WishlistProvider = ({ children }) => {
         return prev;
       });
     }
-    socket.on('wishlist_update', handleWishlistUpdate);
+    if (socket) {
+      socket.on('wishlist_update', handleWishlistUpdate);
+    }
     return () => {
-      socket.off('wishlist_update', handleWishlistUpdate);
+      if (socket) {
+        socket.off('wishlist_update', handleWishlistUpdate);
+      }
     };
   }, []);
 

--- a/client/src/components/NotificationBell.jsx
+++ b/client/src/components/NotificationBell.jsx
@@ -494,16 +494,20 @@ export default function NotificationBell({ mobile = false }) {
       triggerBellRing(); // Ring bell for watchlist notifications
     };
     
-    socket.on('notificationCreated', handleNewNotification);
-    socket.on('allNotificationsMarkedAsRead', handleAllNotificationsMarkedAsRead);
-    socket.on('notificationMarkedAsRead', handleNotificationMarkedAsRead);
-    socket.on('watchlistNotification', handleWatchlistNotification);
+    if (socket) {
+      socket.on('notificationCreated', handleNewNotification);
+      socket.on('allNotificationsMarkedAsRead', handleAllNotificationsMarkedAsRead);
+      socket.on('notificationMarkedAsRead', handleNotificationMarkedAsRead);
+      socket.on('watchlistNotification', handleWatchlistNotification);
+    }
     
     return () => {
-      socket.off('notificationCreated', handleNewNotification);
-      socket.off('allNotificationsMarkedAsRead', handleAllNotificationsMarkedAsRead);
-      socket.off('notificationMarkedAsRead', handleNotificationMarkedAsRead);
-      socket.off('watchlistNotification', handleWatchlistNotification);
+      if (socket) {
+        socket.off('notificationCreated', handleNewNotification);
+        socket.off('allNotificationsMarkedAsRead', handleAllNotificationsMarkedAsRead);
+        socket.off('notificationMarkedAsRead', handleNotificationMarkedAsRead);
+        socket.off('watchlistNotification', handleWatchlistNotification);
+      }
     };
   }, [currentUser]);
 

--- a/client/src/components/ReviewList.jsx
+++ b/client/src/components/ReviewList.jsx
@@ -80,7 +80,8 @@ export default function ReviewList({ listingId, onReviewDeleted, listingOwnerId 
         fetchReplies(updatedReview._id);
       }
     };
-    socket.on('reviewUpdated', handleSocketReviewUpdate);
+    if (socket) {
+      socket.on('reviewUpdated', handleSocketReviewUpdate);
     // Listen for real-time reply updates
     const handleSocketReplyUpdate = ({ action, replies, reviewId, reply, replyId }) => {
       if (action === 'updatedAll' && reviewId && replies) {
@@ -91,7 +92,7 @@ export default function ReviewList({ listingId, onReviewDeleted, listingOwnerId 
         fetchReplies(reply.reviewId);
       }
     };
-    socket.on('reviewReplyUpdated', handleSocketReplyUpdate);
+      socket.on('reviewReplyUpdated', handleSocketReplyUpdate);
     
     // Listen for profile updates to update user info in reviews and replies
     const handleProfileUpdate = (profileData) => {
@@ -126,16 +127,19 @@ export default function ReviewList({ listingId, onReviewDeleted, listingOwnerId 
         return updated;
       });
     };
-    socket.on('profileUpdated', handleProfileUpdate);
+      socket.on('profileUpdated', handleProfileUpdate);
 
-    
-    // Test socket connection with a simple event
-    socket.emit('testConnection', { message: 'ReviewList component connected' });
+      
+      // Test socket connection with a simple event
+      socket.emit('testConnection', { message: 'ReviewList component connected' });
+    }
     
     return () => {
-      socket.off('reviewUpdated', handleSocketReviewUpdate);
-      socket.off('reviewReplyUpdated', handleSocketReplyUpdate);
-      socket.off('profileUpdated', handleProfileUpdate);
+      if (socket) {
+        socket.off('reviewUpdated', handleSocketReviewUpdate);
+        socket.off('reviewReplyUpdated', handleSocketReplyUpdate);
+        socket.off('profileUpdated', handleProfileUpdate);
+      }
 
       // Restore body scroll when component unmounts
       document.body.style.overflow = 'unset';

--- a/client/src/pages/AdminAppointments.jsx
+++ b/client/src/pages/AdminAppointments.jsx
@@ -233,7 +233,9 @@ export default function AdminAppointments() {
         return updated;
       }));
     };
-    socket.on('profileUpdated', handleProfileUpdate);
+    if (socket) {
+      socket.on('profileUpdated', handleProfileUpdate);
+    }
 
     // Listen for real-time comment updates to refresh appointments
     const handleCommentUpdate = (data) => {
@@ -322,29 +324,31 @@ export default function AdminAppointments() {
         };
       });
     };
-    socket.on('commentUpdate', handleCommentUpdate);
+    if (socket) {
+      socket.on('commentUpdate', handleCommentUpdate);
 
-    // Listen for appointment updates
-    const handleAppointmentUpdate = (data) => {
-      setAppointments(prev => 
-        prev.map(appt => 
-          appt._id === data.appointmentId ? { ...appt, ...data.updatedAppointment } : appt
-        )
-      );
-      setArchivedAppointments(prev => 
-        prev.map(appt => 
-          appt._id === data.appointmentId ? { ...appt, ...data.updatedAppointment } : appt
-        )
-      );
-    };
-    socket.on('appointmentUpdate', handleAppointmentUpdate);
+      // Listen for appointment updates
+      const handleAppointmentUpdate = (data) => {
+        setAppointments(prev => 
+          prev.map(appt => 
+            appt._id === data.appointmentId ? { ...appt, ...data.updatedAppointment } : appt
+          )
+        );
+        setArchivedAppointments(prev => 
+          prev.map(appt => 
+            appt._id === data.appointmentId ? { ...appt, ...data.updatedAppointment } : appt
+          )
+        );
+      };
+      socket.on('appointmentUpdate', handleAppointmentUpdate);
 
-    // Listen for new appointments
-    const handleAppointmentCreated = (data) => {
-      const newAppt = data.appointment;
-      setAppointments(prev => [newAppt, ...prev]);
-    };
-    socket.on('appointmentCreated', handleAppointmentCreated);
+      // Listen for new appointments
+      const handleAppointmentCreated = (data) => {
+        const newAppt = data.appointment;
+        setAppointments(prev => [newAppt, ...prev]);
+      };
+      socket.on('appointmentCreated', handleAppointmentCreated);
+    }
 
     // Listen for socket connection events
     const handleConnect = () => {
@@ -359,18 +363,22 @@ export default function AdminAppointments() {
     const handleDisconnect = () => {
       // Socket disconnected - will auto-reconnect
     };
-    socket.on('connect', handleConnect);
-    socket.on('disconnect', handleDisconnect);
+    if (socket) {
+      socket.on('connect', handleConnect);
+      socket.on('disconnect', handleDisconnect);
+    }
     
     return () => {
       clearInterval(interval);
       clearInterval(adminInterval);
-      socket.off('profileUpdated', handleProfileUpdate);
-      socket.off('commentUpdate', handleCommentUpdate);
-      socket.off('appointmentUpdate', handleAppointmentUpdate);
-      socket.off('appointmentCreated', handleAppointmentCreated);
-      socket.off('connect', handleConnect);
-      socket.off('disconnect', handleDisconnect);
+      if (socket) {
+        socket.off('profileUpdated', handleProfileUpdate);
+        socket.off('commentUpdate', handleCommentUpdate);
+        socket.off('appointmentUpdate', handleAppointmentUpdate);
+        socket.off('appointmentCreated', handleAppointmentCreated);
+        socket.off('connect', handleConnect);
+        socket.off('disconnect', handleDisconnect);
+      }
     };
   }, [fetchAppointments, fetchArchivedAppointments, currentUser]);
 
@@ -1974,9 +1982,13 @@ function AdminAppointmentRow({
         toast.info(`New message from ${senderName}`);
       }
     }
-    socket.on('commentUpdate', handleCommentUpdateNotify);
+    if (socket) {
+      socket.on('commentUpdate', handleCommentUpdateNotify);
+    }
     return () => {
-      socket.off('commentUpdate', handleCommentUpdateNotify);
+      if (socket) {
+        socket.off('commentUpdate', handleCommentUpdateNotify);
+      }
     };
   }, [appt._id, showChatModal]);
 
@@ -1999,11 +2011,15 @@ function AdminAppointmentRow({
       setReactionsMessageId(null);
     }
 
-    socket.on('chatClearedForUser', handleChatClearedForUser);
-    socket.on('commentRemovedForUser', handleCommentRemovedForUser);
+    if (socket) {
+      socket.on('chatClearedForUser', handleChatClearedForUser);
+      socket.on('commentRemovedForUser', handleCommentRemovedForUser);
+    }
     return () => {
-      socket.off('chatClearedForUser', handleChatClearedForUser);
-      socket.off('commentRemovedForUser', handleCommentRemovedForUser);
+      if (socket) {
+        socket.off('chatClearedForUser', handleChatClearedForUser);
+        socket.off('commentRemovedForUser', handleCommentRemovedForUser);
+      }
     };
   }, [appt._id]);
 
@@ -2041,14 +2057,18 @@ function AdminAppointmentRow({
         setReactionsMessageId(null);
       }
     };
-    socket.on('chatCleared', handleChatCleared);
-    socket.on('commentDelivered', handleCommentDelivered);
-    socket.on('commentRead', handleCommentRead);
+    if (socket) {
+      socket.on('chatCleared', handleChatCleared);
+      socket.on('commentDelivered', handleCommentDelivered);
+      socket.on('commentRead', handleCommentRead);
+    }
     
     return () => {
-      socket.off('chatCleared', handleChatCleared);
-      socket.off('commentDelivered', handleCommentDelivered);
-      socket.off('commentRead', handleCommentRead);
+      if (socket) {
+        socket.off('chatCleared', handleChatCleared);
+        socket.off('commentDelivered', handleCommentDelivered);
+        socket.off('commentRead', handleCommentRead);
+      }
     };
   }, [appt._id, showChatModal, currentUser.email, isAtBottom]);
 

--- a/client/src/pages/AdminManagement.jsx
+++ b/client/src/pages/AdminManagement.jsx
@@ -63,11 +63,15 @@ export default function AdminManagement() {
         return prev;
       });
     }
-    socket.on('user_update', handleUserUpdate);
-    socket.on('admin_update', handleAdminUpdate);
+    if (socket) {
+      socket.on('user_update', handleUserUpdate);
+      socket.on('admin_update', handleAdminUpdate);
+    }
     return () => {
-      socket.off('user_update', handleUserUpdate);
-      socket.off('admin_update', handleAdminUpdate);
+      if (socket) {
+        socket.off('user_update', handleUserUpdate);
+        socket.off('admin_update', handleAdminUpdate);
+      }
     };
   }, []);
 

--- a/client/src/pages/AdminReviews.jsx
+++ b/client/src/pages/AdminReviews.jsx
@@ -80,26 +80,30 @@ export default function AdminReviews() {
         }
       });
     };
-    socket.on('reviewUpdated', handleSocketReviewUpdate);
-    
-    // Listen for profile updates to update user info in reviews
-    const handleProfileUpdate = (profileData) => {
-      setReviews(prevReviews => prevReviews.map(review => {
-        if (review.userId === profileData.userId) {
-          return {
-            ...review,
-            userName: profileData.username,
-            userAvatar: profileData.avatar
-          };
-        }
-        return review;
-      }));
-    };
-    socket.on('profileUpdated', handleProfileUpdate);
+    if (socket) {
+      socket.on('reviewUpdated', handleSocketReviewUpdate);
+      
+      // Listen for profile updates to update user info in reviews
+      const handleProfileUpdate = (profileData) => {
+        setReviews(prevReviews => prevReviews.map(review => {
+          if (review.userId === profileData.userId) {
+            return {
+              ...review,
+              userName: profileData.username,
+              userAvatar: profileData.avatar
+            };
+          }
+          return review;
+        }));
+      };
+      socket.on('profileUpdated', handleProfileUpdate);
+    }
     
     return () => {
-      socket.off('reviewUpdated', handleSocketReviewUpdate);
-      socket.off('profileUpdated', handleProfileUpdate);
+      if (socket) {
+        socket.off('reviewUpdated', handleSocketReviewUpdate);
+        socket.off('profileUpdated', handleProfileUpdate);
+      }
     };
   }, [currentUser, currentPage, selectedStatus, sortBy, sortOrder]);
 

--- a/client/src/pages/MyAppointments.jsx
+++ b/client/src/pages/MyAppointments.jsx
@@ -209,9 +209,13 @@ export default function MyAppointments() {
         )
       );
     }
-    socket.on('appointmentUpdate', handleAppointmentUpdate);
+    if (socket) {
+      socket.on('appointmentUpdate', handleAppointmentUpdate);
+    }
     return () => {
-      socket.off('appointmentUpdate', handleAppointmentUpdate);
+      if (socket) {
+        socket.off('appointmentUpdate', handleAppointmentUpdate);
+      }
     };
   }, []);
 
@@ -226,43 +230,47 @@ export default function MyAppointments() {
       }
       setAppointments((prev) => [appt, ...prev]);
     }
-    socket.on('appointmentCreated', handleAppointmentCreated);
-    
-    // Listen for profile updates to update user info in appointments
-    const handleProfileUpdate = (profileData) => {
-      setAppointments(prevAppointments => prevAppointments.map(appt => {
-        const updated = { ...appt };
-        
-        // Update buyer info if the updated user is the buyer
-        if (appt.buyerId && (appt.buyerId._id === profileData.userId || appt.buyerId === profileData.userId)) {
-          updated.buyerId = {
-            ...updated.buyerId,
-            username: profileData.username,
-            email: profileData.email,
-            mobileNumber: profileData.mobileNumber,
-            avatar: profileData.avatar
-          };
-        }
-        
-        // Update seller info if the updated user is the seller
-        if (appt.sellerId && (appt.sellerId._id === profileData.userId || appt.sellerId === profileData.userId)) {
-          updated.sellerId = {
-            ...updated.sellerId,
-            username: profileData.username,
-            email: profileData.email,
-            mobileNumber: profileData.mobileNumber,
-            avatar: profileData.avatar
-          };
-        }
-        
-        return updated;
-      }));
-    };
-    socket.on('profileUpdated', handleProfileUpdate);
+    if (socket) {
+      socket.on('appointmentCreated', handleAppointmentCreated);
+      
+      // Listen for profile updates to update user info in appointments
+      const handleProfileUpdate = (profileData) => {
+        setAppointments(prevAppointments => prevAppointments.map(appt => {
+          const updated = { ...appt };
+          
+          // Update buyer info if the updated user is the buyer
+          if (appt.buyerId && (appt.buyerId._id === profileData.userId || appt.buyerId === profileData.userId)) {
+            updated.buyerId = {
+              ...updated.buyerId,
+              username: profileData.username,
+              email: profileData.email,
+              mobileNumber: profileData.mobileNumber,
+              avatar: profileData.avatar
+            };
+          }
+          
+          // Update seller info if the updated user is the seller
+          if (appt.sellerId && (appt.sellerId._id === profileData.userId || appt.sellerId === profileData.userId)) {
+            updated.sellerId = {
+              ...updated.sellerId,
+              username: profileData.username,
+              email: profileData.email,
+              mobileNumber: profileData.mobileNumber,
+              avatar: profileData.avatar
+            };
+          }
+          
+          return updated;
+        }));
+      };
+      socket.on('profileUpdated', handleProfileUpdate);
+    }
     
     return () => {
-      socket.off('appointmentCreated', handleAppointmentCreated);
-      socket.off('profileUpdated', handleProfileUpdate);
+      if (socket) {
+        socket.off('appointmentCreated', handleAppointmentCreated);
+        socket.off('profileUpdated', handleProfileUpdate);
+      }
     };
   }, [currentUser]);
 
@@ -3696,13 +3704,17 @@ function AppointmentRow({ appt, currentUser, handleStatusUpdate, handleAdminDele
       addLocallyRemovedId(appt._id, commentId);
     }
 
-    socket.on('commentUpdate', handleCommentUpdate);
-    socket.on('chatClearedForUser', handleChatClearedForUser);
-    socket.on('commentRemovedForUser', handleCommentRemovedForUser);
+    if (socket) {
+      socket.on('commentUpdate', handleCommentUpdate);
+      socket.on('chatClearedForUser', handleChatClearedForUser);
+      socket.on('commentRemovedForUser', handleCommentRemovedForUser);
+    }
     return () => {
-      socket.off('commentUpdate', handleCommentUpdate);
-      socket.off('chatClearedForUser', handleChatClearedForUser);
-      socket.off('commentRemovedForUser', handleCommentRemovedForUser);
+      if (socket) {
+        socket.off('commentUpdate', handleCommentUpdate);
+        socket.off('chatClearedForUser', handleChatClearedForUser);
+        socket.off('commentRemovedForUser', handleCommentRemovedForUser);
+      }
     };
   }, [appt._id, currentUser.email, currentUser._id, showChatModal, playNotification, playMessageReceived]);
 
@@ -3766,11 +3778,15 @@ function AppointmentRow({ appt, currentUser, handleStatusUpdate, handleAdminDele
         );
       }
     }
-    socket.on('commentDelivered', handleCommentDelivered);
-    socket.on('commentRead', handleCommentRead);
+    if (socket) {
+      socket.on('commentDelivered', handleCommentDelivered);
+      socket.on('commentRead', handleCommentRead);
+    }
     return () => {
-      socket.off('commentDelivered', handleCommentDelivered);
-      socket.off('commentRead', handleCommentRead);
+      if (socket) {
+        socket.off('commentDelivered', handleCommentDelivered);
+        socket.off('commentRead', handleCommentRead);
+      }
     };
   }, [appt._id, setComments]);
 
@@ -3872,11 +3888,15 @@ function AppointmentRow({ appt, currentUser, handleStatusUpdate, handleAdminDele
         setOtherPartyLastSeen(data.lastSeen || null);
       }
     }
-    socket.on('userOnlineStatus', handleUserOnlineStatus);
-    socket.on('userOnlineUpdate', handleUserOnlineStatus);
+    if (socket) {
+      socket.on('userOnlineStatus', handleUserOnlineStatus);
+      socket.on('userOnlineUpdate', handleUserOnlineStatus);
+    }
     return () => {
-      socket.off('userOnlineStatus', handleUserOnlineStatus);
-      socket.off('userOnlineUpdate', handleUserOnlineStatus);
+      if (socket) {
+        socket.off('userOnlineStatus', handleUserOnlineStatus);
+        socket.off('userOnlineUpdate', handleUserOnlineStatus);
+      }
     };
   }, [showChatModal, otherParty?._id]);
 
@@ -3895,12 +3915,16 @@ function AppointmentRow({ appt, currentUser, handleStatusUpdate, handleAdminDele
       }
     }
     
-    socket.on('userOnlineStatus', handleTableUserOnlineStatus);
-    socket.on('userOnlineUpdate', handleTableUserOnlineStatus);
+    if (socket) {
+      socket.on('userOnlineStatus', handleTableUserOnlineStatus);
+      socket.on('userOnlineUpdate', handleTableUserOnlineStatus);
+    }
     
     return () => {
-      socket.off('userOnlineStatus', handleTableUserOnlineStatus);
-      socket.off('userOnlineUpdate', handleTableUserOnlineStatus);
+      if (socket) {
+        socket.off('userOnlineStatus', handleTableUserOnlineStatus);
+        socket.off('userOnlineUpdate', handleTableUserOnlineStatus);
+      }
     };
   }, [otherParty?._id]);
 
@@ -3913,9 +3937,13 @@ function AppointmentRow({ appt, currentUser, handleStatusUpdate, handleAdminDele
         typingTimeoutRef.current = setTimeout(() => setIsOtherPartyTyping(false), 1000);
       }
     }
-    socket.on('typing', handleTyping);
+    if (socket) {
+      socket.on('typing', handleTyping);
+    }
     return () => {
-      socket.off('typing', handleTyping);
+      if (socket) {
+        socket.off('typing', handleTyping);
+      }
       if (typingTimeoutRef.current) clearTimeout(typingTimeoutRef.current);
     };
   }, [otherParty?._id, appt._id]);

--- a/client/src/pages/UserReviews.jsx
+++ b/client/src/pages/UserReviews.jsx
@@ -91,31 +91,34 @@ export default function UserReviews() {
         );
       });
     };
-    socket.on('reviewUpdated', handleSocketReviewUpdate);
-    
-    // Listen for profile updates to update user info in reviews
-    const handleProfileUpdate = (profileData) => {
-      setReviews(prevReviews => {
-        const updated = prevReviews.map(review => {
-          if (review.userId === profileData.userId) {
-            return {
-              ...review,
-              userName: profileData.username,
-              userAvatar: profileData.avatar
-            };
-          }
-          return review;
+    if (socket) {
+      socket.on('reviewUpdated', handleSocketReviewUpdate);
+      
+      // Listen for profile updates to update user info in reviews
+      const handleProfileUpdate = (profileData) => {
+        setReviews(prevReviews => {
+          const updated = prevReviews.map(review => {
+            if (review.userId === profileData.userId) {
+              return {
+                ...review,
+                userName: profileData.username,
+                userAvatar: profileData.avatar
+              };
+            }
+            return review;
+          });
+          return updated;
         });
-        return updated;
-      });
-    };
-    socket.on('profileUpdated', handleProfileUpdate);
+      };
+      socket.on('profileUpdated', handleProfileUpdate);
+    }
 
     
     return () => {
-      socket.off('reviewUpdated', handleSocketReviewUpdate);
-      socket.off('profileUpdated', handleProfileUpdate);
-
+      if (socket) {
+        socket.off('reviewUpdated', handleSocketReviewUpdate);
+        socket.off('profileUpdated', handleProfileUpdate);
+      }
     };
   }, [currentUser]);
 

--- a/client/src/pages/Watchlist.jsx
+++ b/client/src/pages/Watchlist.jsx
@@ -160,10 +160,14 @@ export default function Watchlist() {
     };
 
     // Listen for watchlist notifications
-    socket.on('watchlistNotification', handleWatchlistNotification);
+    if (socket) {
+      socket.on('watchlistNotification', handleWatchlistNotification);
+    }
 
     return () => {
-      socket.off('watchlistNotification', handleWatchlistNotification);
+      if (socket) {
+        socket.off('watchlistNotification', handleWatchlistNotification);
+      }
     };
   }, [currentUser?._id, socket]);
   


### PR DESCRIPTION
Add null checks for socket connections to prevent `TypeError: Cannot read properties of null (reading 'on')` when users are unauthenticated.

---
<a href="https://cursor.com/background-agent?bcId=bc-d27c13bd-ccdf-4f63-9d95-c6f8fd266f20">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d27c13bd-ccdf-4f63-9d95-c6f8fd266f20">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

