### PR TITLE
Fix profile email otp, add otp copy, and update password page colors

### DIFF
--- a/api/middleware/csrf.js
+++ b/api/middleware/csrf.js
@@ -85,9 +85,20 @@ export const verifyCSRFToken = (req, res, next) => {
             return next(errorHandler(403, 'CSRF token mismatch'));
         }
         
-        // Remove used token (one-time use)
-        csrfTokenStore.delete(token);
-        console.log('CSRF token verified and consumed successfully');
+        // Remove used token (one-time use) - except for OTP endpoints which need multiple uses
+        const isOTPEndpoint = req.path.includes('/send-otp') || 
+                             req.path.includes('/verify-otp') || 
+                             req.path.includes('/send-forgot-password-otp') || 
+                             req.path.includes('/send-profile-email-otp') || 
+                             req.path.includes('/send-login-otp') || 
+                             req.path.includes('/verify-login-otp');
+        
+        if (!isOTPEndpoint) {
+            csrfTokenStore.delete(token);
+            console.log('CSRF token verified and consumed successfully');
+        } else {
+            console.log('CSRF token verified for OTP endpoint (not consumed)');
+        }
         
         next();
     } catch (error) {

--- a/client/src/components/AdminHeader.jsx
+++ b/client/src/components/AdminHeader.jsx
@@ -101,7 +101,7 @@ export default function AdminHeader() {
         return 'bg-gradient-to-r from-red-600 to-red-700'; // Red for forgot-password verification step
       case '/change-password':
       case '/admin/change-password':
-        return 'bg-gradient-to-r from-green-600 to-green-700'; // Green for change-password
+        return 'bg-gradient-to-r from-blue-600 to-blue-700'; // Blue for change-password
       default:
         return 'bg-gradient-to-r from-blue-700 to-purple-700'; // Default blue-purple
     }
@@ -126,7 +126,7 @@ export default function AdminHeader() {
         return 'bg-red-500 hover:bg-red-600'; // Red for forgot-password verification step
       case '/change-password':
       case '/admin/change-password':
-        return 'bg-green-500 hover:bg-green-600'; // Green for change-password
+        return 'bg-blue-500 hover:bg-blue-600'; // Blue for change-password
       default:
         return 'bg-blue-500 hover:bg-blue-600'; // Default blue
     }

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -105,7 +105,7 @@ export default function Header() {
         return 'bg-gradient-to-r from-red-600 to-red-700'; // Red for forgot-password verification step
       case '/change-password':
       case '/user/change-password':
-        return 'bg-gradient-to-r from-green-600 to-green-700'; // Green for change-password
+        return 'bg-gradient-to-r from-blue-600 to-blue-700'; // Blue for change-password
       default:
         return 'bg-gradient-to-r from-blue-700 to-purple-700'; // Default blue-purple
     }
@@ -140,7 +140,7 @@ export default function Header() {
         return 'bg-red-500 hover:bg-red-600'; // Red for forgot-password verification step
       case '/change-password':
       case '/user/change-password':
-        return 'bg-green-500 hover:bg-green-600'; // Green for change-password
+        return 'bg-blue-500 hover:bg-blue-600'; // Blue for change-password
       default:
         return 'bg-blue-500 hover:bg-blue-600'; // Default blue
     }


### PR DESCRIPTION
Fix OTP sending errors by preventing CSRF token consumption for OTP endpoints and update change password page header colors.

The CSRF token was being consumed (deleted) after each request, causing subsequent OTP-related requests (like sending and verifying OTP) to fail with a 500 Internal Server Error. This change modifies the CSRF middleware to allow OTP endpoints to reuse the token for the duration of the OTP flow.

---
<a href="https://cursor.com/background-agent?bcId=bc-c8c18d7b-3c0f-4bc4-a1e6-d46d0973f45b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c8c18d7b-3c0f-4bc4-a1e6-d46d0973f45b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

