### PR TITLE
Fix refund management bugs and appointment page error

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -64,6 +64,7 @@
         "multer-storage-cloudinary": "^4.0.0",
         "nodemailer": "^7.0.5",
         "nodemon": "^3.1.10",
+        "pdfkit": "^0.15.0",
         "react-hot-toast": "^2.5.2",
         "react-swipeable": "^7.0.2",
         "socket.io": "^4.8.1"

--- a/client/src/pages/MyAppointments.jsx
+++ b/client/src/pages/MyAppointments.jsx
@@ -1364,6 +1364,10 @@ function AppointmentRow({ appt, currentUser, handleStatusUpdate, handleAdminDele
   const [removingLock, setRemovingLock] = useState(false);
   const [forgotPasswordProcessing, setForgotPasswordProcessing] = useState(false);
   
+  // Refund and appeal modal states
+  const [showRefundRequestModal, setShowRefundRequestModal] = useState(false);
+  const [showAppealModal, setShowAppealModal] = useState(false);
+  
   // Lock body scroll when specific modals are open (Cancel or Remove Appointment)
   useEffect(() => {
     const shouldLock = showCancelModal || showPermanentDeleteModal;


### PR DESCRIPTION
Add missing `showRefundRequestModal` and `showAppealModal` state variables to `MyAppointments` component to fix a `ReferenceError` causing the page to go blank.

---
<a href="https://cursor.com/background-agent?bcId=bc-358bf603-fb4f-4769-990b-2e93608fd131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-358bf603-fb4f-4769-990b-2e93608fd131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

