### PR TITLE
Fix otp email required errors for deletion and transfer

### DIFF
--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -1055,7 +1055,7 @@ export default function Profile() {
     setDeleteOtpSent(false);
     try {
       setDeleteProcessing(true);
-      const sendRes = await authenticatedFetch(`${API_BASE_URL}/api/auth/send-account-deletion-otp`, { method:'POST', body: JSON.stringify({}) });
+      const sendRes = await authenticatedFetch(`${API_BASE_URL}/api/auth/send-account-deletion-otp`, { method:'POST', body: JSON.stringify({ email: currentUser.email }) });
       const sendData = await sendRes.json();
       if (!sendRes.ok || sendData.success === false) {
         setDeleteError(sendData.message || 'Failed to send OTP');
@@ -1071,7 +1071,7 @@ export default function Profile() {
 
   const resendDeleteOtp = async () => {
     try {
-      const res = await authenticatedFetch(`${API_BASE_URL}/api/auth/send-account-deletion-otp`, { method:'POST', body: JSON.stringify({}) });
+      const res = await authenticatedFetch(`${API_BASE_URL}/api/auth/send-account-deletion-otp`, { method:'POST', body: JSON.stringify({ email: currentUser.email }) });
       const data = await res.json();
       return res.ok && data.success !== false;
     } catch (_) { return false; }
@@ -1169,7 +1169,7 @@ export default function Profile() {
       // Send OTP to root admin email
       const sendRes = await authenticatedFetch(`${API_BASE_URL}/api/auth/send-transfer-rights-otp`, {
         method: 'POST',
-        body: JSON.stringify({})
+        body: JSON.stringify({ email: currentUser.email })
       });
       const sendData = await sendRes.json();
       if (!sendRes.ok || sendData.success === false) {
@@ -1189,7 +1189,7 @@ export default function Profile() {
 
   const resendTransferOtp = async () => {
     try {
-      const res = await authenticatedFetch(`${API_BASE_URL}/api/auth/send-transfer-rights-otp`, { method:'POST', body: JSON.stringify({}) });
+      const res = await authenticatedFetch(`${API_BASE_URL}/api/auth/send-transfer-rights-otp`, { method:'POST', body: JSON.stringify({ email: currentUser.email }) });
       const data = await res.json();
       return res.ok && data.success !== false;
     } catch (_) { return false; }
@@ -1345,7 +1345,7 @@ export default function Profile() {
       // Step 2: send OTP
       const sendRes = await authenticatedFetch(`${API_BASE_URL}/api/auth/send-transfer-rights-otp`, {
         method: 'POST',
-        body: JSON.stringify({})
+        body: JSON.stringify({ email: currentUser.email })
       });
       const sendData = await sendRes.json();
       if (!sendRes.ok || sendData.success === false) {


### PR DESCRIPTION
Include `currentUser.email` in OTP requests for account deletion and admin rights transfer to resolve "Email is required" errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-4c251652-a590-4088-a3c9-3d0fb375586f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4c251652-a590-4088-a3c9-3d0fb375586f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

