### PR TITLE
Fix listing page syntax error and deploy

### DIFF
--- a/client/src/pages/Listing.jsx
+++ b/client/src/pages/Listing.jsx
@@ -1151,7 +1151,8 @@ export default function Listing() {
                     </div>
                   </div>
                 </SwiperSlide>
-              )})();
+              )
+              })()}
             </Swiper>
           </div>
 


### PR DESCRIPTION
Fixes Vercel deployment failure by correcting a JSX IIFE syntax error in `Listing.jsx`.

The build error `Expected "}" but found ";"` occurred because an IIFE `)();` was incorrectly placed within JSX. The fix moves the closing parenthesis `)` to correctly wrap the `SwiperSlide` component before the IIFE invocation `()}`.

---
<a href="https://cursor.com/background-agent?bcId=bc-d8bb4e1e-d241-4f7f-bc30-cd22468548d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d8bb4e1e-d241-4f7f-bc30-cd22468548d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

