### PR TITLE
Fix sequential image and video display in chatbox

### DIFF
--- a/client/src/components/ChatMediaPreview.jsx
+++ b/client/src/components/ChatMediaPreview.jsx
@@ -1,0 +1,110 @@
+import React, { useEffect, useState, useCallback } from 'react';
+
+// Unified media preview for chat: supports images and videos in a single sequence
+// media: Array<{ type: 'image'|'video', url: string }>
+const ChatMediaPreview = ({ isOpen, onClose, media = [], initialIndex = 0 }) => {
+  const [currentIndex, setCurrentIndex] = useState(initialIndex || 0);
+  const [isKeybound, setIsKeybound] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      setCurrentIndex(initialIndex || 0);
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isOpen, initialIndex]);
+
+  const goPrev = useCallback(() => {
+    setCurrentIndex((prev) => (prev > 0 ? prev - 1 : (media.length > 0 ? media.length - 1 : 0)));
+  }, [media.length]);
+
+  const goNext = useCallback(() => {
+    setCurrentIndex((prev) => (prev < media.length - 1 ? prev + 1 : 0));
+  }, [media.length]);
+
+  useEffect(() => {
+    if (!isOpen || isKeybound) return;
+    const onKeyDown = (e) => {
+      if (!isOpen) return;
+      if (e.key === 'Escape') onClose?.();
+      if (e.key === 'ArrowLeft') goPrev();
+      if (e.key === 'ArrowRight') goNext();
+    };
+    setIsKeybound(true);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      setIsKeybound(false);
+    };
+  }, [isOpen, goPrev, goNext, onClose, isKeybound]);
+
+  if (!isOpen || !media || media.length === 0) return null;
+
+  const item = media[currentIndex];
+
+  return (
+    <div className="fixed inset-0 z-[9999] bg-black/95 flex items-center justify-center">
+      <button
+        aria-label="Close"
+        onClick={onClose}
+        className="absolute top-4 right-4 text-white hover:text-red-400 bg-black/70 rounded-full p-3 transition-all duration-200 hover:bg-black/90 hover:scale-110"
+      >
+        ✕
+      </button>
+
+      {media.length > 1 && (
+        <>
+          <button
+            aria-label="Previous"
+            onClick={goPrev}
+            className="absolute left-4 top-1/2 -translate-y-1/2 text-white hover:text-blue-300 bg-black/70 rounded-full p-4 transition-all duration-200 hover:bg-black/90 hover:scale-110"
+          >
+            ‹
+          </button>
+          <button
+            aria-label="Next"
+            onClick={goNext}
+            className="absolute right-4 top-1/2 -translate-y-1/2 text-white hover:text-blue-300 bg-black/70 rounded-full p-4 transition-all duration-200 hover:bg-black/90 hover:scale-110"
+          >
+            ›
+          </button>
+        </>
+      )}
+
+      {/* Counter */}
+      <div className="absolute top-4 left-1/2 -translate-x-1/2 text-white text-sm bg-black/60 px-3 py-1 rounded-full">
+        {currentIndex + 1} / {media.length}
+      </div>
+
+      <div className="relative w-full h-full max-h-[92vh] flex items-center justify-center p-4">
+        {item?.type === 'video' ? (
+          <video
+            key={`video-${currentIndex}`}
+            src={item.url}
+            className="w-full h-full max-h-[92vh] object-contain rounded"
+            controls
+            autoPlay
+          />
+        ) : (
+          <img
+            key={`image-${currentIndex}`}
+            src={item?.url}
+            alt="Chat media"
+            className="w-full h-full max-h-[92vh] object-contain rounded"
+            onError={(e) => {
+              e.currentTarget.src = 'https://via.placeholder.com/800x600?text=Media+Not+Available';
+              e.currentTarget.className = 'w-full h-full max-h-[92vh] object-contain rounded opacity-60';
+            }}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ChatMediaPreview;
+

--- a/client/src/pages/AdminAppointments.jsx
+++ b/client/src/pages/AdminAppointments.jsx
@@ -5109,13 +5109,16 @@ function AdminAppointmentRow({
                                             onClick={(e) => {
                                               e.preventDefault();
                                               e.stopPropagation();
-                                              if (e.target.requestFullscreen) {
-                                                e.target.requestFullscreen();
-                                              } else if (e.target.webkitRequestFullscreen) {
-                                                e.target.webkitRequestFullscreen();
-                                              } else if (e.target.msRequestFullscreen) {
-                                                e.target.msRequestFullscreen();
-                                              }
+                                              const media = (localComments || [])
+                                                .filter(msg => (msg.originalImageUrl || msg.imageUrl || msg.videoUrl))
+                                                .map(msg => {
+                                                  if (msg.originalImageUrl || msg.imageUrl) return { type: 'image', url: msg.originalImageUrl || msg.imageUrl };
+                                                  return { type: 'video', url: msg.videoUrl };
+                                                });
+                                              const startIndex = Math.max(0, media.findIndex(m => m.url === c.videoUrl));
+                                              setChatMediaItems(media);
+                                              setChatMediaStartIndex(startIndex);
+                                              setShowChatMediaPreview(true);
                                             }}
                                           />
                                           <div className={`mt-1 text-xs ${isMe ? 'text-blue-100' : 'text-gray-500'}`}>


### PR DESCRIPTION
Implement a unified chat media preview to allow sequential navigation through images and videos and ensure a consistent close experience.

The previous implementation only supported image previews and native fullscreen for videos, which lacked a consistent user experience and sequential navigation across different media types. This PR introduces a single modal that handles both images and videos, providing a WhatsApp-style browsing experience with clear navigation and a close button.

---
<a href="https://cursor.com/background-agent?bcId=bc-7f41066c-ad46-4657-abae-b95876509d48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7f41066c-ad46-4657-abae-b95876509d48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

